### PR TITLE
feat: implement Zustand theme store with localStorage persistence

### DIFF
--- a/frontend/src/store/themeStore.ts
+++ b/frontend/src/store/themeStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeState {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      theme: 'light',
+      toggleTheme: () =>
+        set((state) => ({
+          theme: state.theme === 'light' ? 'dark' : 'light',
+        })),
+      setTheme: (theme: Theme) => set({ theme }),
+    }),
+    {
+      name: 'resumify-theme',
+    }
+  )
+);
+


### PR DESCRIPTION
- Create themeStore.ts with Zustand store
- Add Theme type ('light' | 'dark')
- Implement toggleTheme() and setTheme() actions
- Add persist middleware with 'resumify-theme' storage key
- Default theme set to 'light'
- Export useThemeStore hook for consumption

Closes #1