### PR TITLE
feat: add AI Resume Updater page with certificate merge and PDF expor…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,5 @@
 GEMINI_API_KEY=
+GEMINI_MODEL=gemini-flash-latest
 DB_NAME=resumify_db
 DB_USER=adeel
 DB_PASSWORD=your_password_here

--- a/backend/ai_updater/tests/test_ai_client.py
+++ b/backend/ai_updater/tests/test_ai_client.py
@@ -1,12 +1,15 @@
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase, override_settings
+from google.api_core import exceptions as google_exceptions
 
 from ai_updater.utils.ai_client import (
+    GeminiAPIError,
     GeminiConfigError,
     GeminiParseError,
     InvalidInputError,
     _ensure_ids,
+    _map_google_api_error,
     _parse_gemini_response,
     update_resume_with_ai,
 )
@@ -200,3 +203,39 @@ class UpdateResumeWithAiTests(SimpleTestCase):
     def test_empty_instructions_raises_invalid_input(self):
         with self.assertRaises(InvalidInputError):
             update_resume_with_ai(self.resume_text, "   ")
+
+    @override_settings(GEMINI_API_KEY="test-key", GEMINI_MODEL="gemini-2.0-flash")
+    @patch("ai_updater.utils.ai_client.genai.GenerativeModel")
+    def test_permission_denied_raises_api_error(self, mock_model_cls):
+        mock_model_cls.return_value.generate_content.side_effect = (
+            google_exceptions.PermissionDenied("API key revoked")
+        )
+
+        with self.assertRaises(GeminiAPIError) as ctx:
+            update_resume_with_ai(self.resume_text, self.instructions)
+
+        self.assertIn("invalid or has been revoked", str(ctx.exception))
+
+    @override_settings(GEMINI_API_KEY="test-key", GEMINI_MODEL="gemini-2.0-flash")
+    @patch("ai_updater.utils.ai_client.genai.GenerativeModel")
+    def test_quota_exceeded_raises_api_error(self, mock_model_cls):
+        mock_model_cls.return_value.generate_content.side_effect = (
+            google_exceptions.ResourceExhausted("quota exceeded")
+        )
+
+        with self.assertRaises(GeminiAPIError) as ctx:
+            update_resume_with_ai(self.resume_text, self.instructions)
+
+        self.assertIn("quota exceeded", str(ctx.exception).lower())
+
+
+class MapGoogleApiErrorTests(SimpleTestCase):
+    @override_settings(GEMINI_MODEL="gemini-2.0-flash")
+    def test_permission_denied_message(self):
+        msg = _map_google_api_error(google_exceptions.PermissionDenied("denied"))
+        self.assertIn("invalid or has been revoked", msg)
+
+    @override_settings(GEMINI_MODEL="gemini-2.0-flash")
+    def test_resource_exhausted_message(self):
+        msg = _map_google_api_error(google_exceptions.ResourceExhausted("quota"))
+        self.assertIn("quota exceeded", msg.lower())

--- a/backend/ai_updater/tests/test_views.py
+++ b/backend/ai_updater/tests/test_views.py
@@ -167,6 +167,28 @@ class AIResumeUpdateViewTests(APITestCase):
 
     @patch("ai_updater.views.update_resume_with_ai")
     @patch("ai_updater.views.extract_resume_text")
+    def test_supporting_file_passed_to_ai(self, mock_extract, mock_update):
+        mock_extract.side_effect = [EXTRACTED_RESUME_TEXT, "supporting doc text"]
+        mock_update.return_value = SAMPLE_RESULT
+        self.client.force_authenticate(user=self.user)
+
+        response = self._post_update(
+            {
+                "file": make_uploaded_pdf(name="resume.pdf"),
+                "supporting_file": make_uploaded_pdf(name="support.pdf"),
+                "instructions": SAMPLE_INSTRUCTIONS,
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(mock_extract.call_count, 2)
+        mock_update.assert_called_once()
+        combined_text = mock_update.call_args.args[0]
+        self.assertIn("PRIMARY RESUME:", combined_text)
+        self.assertIn("SUPPORTING DOCUMENT:", combined_text)
+
+    @patch("ai_updater.views.update_resume_with_ai")
+    @patch("ai_updater.views.extract_resume_text")
     def test_parser_value_error_returns_400(self, mock_extract, mock_update):
         mock_extract.side_effect = ValueError("Could not parse PDF: corrupt file.")
         self.client.force_authenticate(user=self.user)
@@ -198,3 +220,22 @@ class AIResumeUpdateViewTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertEqual(response.data["error"], "AI processing failed. Please try again.")
+
+    @patch("ai_updater.views.update_resume_with_ai")
+    @patch("ai_updater.views.extract_resume_text")
+    def test_gemini_api_error_returns_503(self, mock_extract, mock_update):
+        from ai_updater.utils.ai_client import GeminiAPIError
+
+        mock_extract.return_value = EXTRACTED_RESUME_TEXT
+        mock_update.side_effect = GeminiAPIError("The AI API key is invalid or has been revoked.")
+        self.client.force_authenticate(user=self.user)
+
+        response = self._post_update(
+            {
+                "file": make_uploaded_pdf(),
+                "instructions": SAMPLE_INSTRUCTIONS,
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertIn("invalid or has been revoked", response.data["error"])

--- a/backend/ai_updater/utils/ai_client.py
+++ b/backend/ai_updater/utils/ai_client.py
@@ -8,8 +8,6 @@ import google.generativeai as genai
 from django.conf import settings
 from google.api_core import exceptions as google_exceptions
 
-MODEL_NAME = "gemini-2.0-flash"
-
 SYSTEM_PROMPT = """You are a professional resume editor. Your task is to parse plain-text resume content into structured JSON and apply the user's requested changes.
 
 RULES:
@@ -17,6 +15,11 @@ RULES:
 {
   "fullName": "string",
   "profileSummary": "string",
+  "contact": {
+    "phone": "string",
+    "email": "string",
+    "location": "string"
+  },
   "experience": [
     {
       "id": "string (UUID, optional)",
@@ -34,7 +37,8 @@ RULES:
       "degree": "string",
       "field": "string",
       "startDate": "string",
-      "endDate": "string"
+      "endDate": "string",
+      "grade": "string (optional)"
     }
   ],
   "skills": ["string"],
@@ -52,9 +56,12 @@ RULES:
       "issuer": "string",
       "date": "string"
     }
-  ]
+  ],
+  "extracurricular": ["string"]
 }
-2. Apply ONLY the changes the user requests. NEVER invent experience, skills, education, languages, or certifications not present in the source text.
+2. The resume text may come from a multi-column PDF and appear out of order. Reconstruct logical sections (Contact, Profile, Work Experience, Education, Skills, Languages, Certifications/Training, Extracurricular) from context.
+3. The resume text may include two blocks: a PRIMARY RESUME and an optional SUPPORTING DOCUMENT. If a supporting document is present, use it only to add missing facts (e.g. internship company, title, dates) and do not remove existing resume content.
+4. Apply ONLY the changes the user requests. NEVER invent experience, skills, education, languages, certifications, or extracurricular items not present in the source text.
 3. Fix grammar and spelling errors across all sections automatically.
 4. Preserve all factual content from the original resume unless the user explicitly asks to change it.
 5. After the JSON object, on a new line, write CHANGES: followed by a human-readable bullet list of every change you made (one change per line, prefixed with "- ").
@@ -66,7 +73,7 @@ CHANGES:
 - Fixed grammar in profile summary
 """
 
-_configured = False
+_configured_key: str | None = None
 
 
 class GeminiConfigError(Exception):
@@ -86,12 +93,31 @@ class InvalidInputError(Exception):
 
 
 def _ensure_configured() -> None:
-    global _configured
+    global _configured_key
     if not settings.GEMINI_API_KEY:
-        raise GeminiConfigError("AI service is not configured.")
-    if not _configured:
+        raise GeminiConfigError(
+            "AI service is not configured. Set GEMINI_API_KEY in backend/.env."
+        )
+    if _configured_key != settings.GEMINI_API_KEY:
         genai.configure(api_key=settings.GEMINI_API_KEY)
-        _configured = True
+        _configured_key = settings.GEMINI_API_KEY
+
+
+def _map_google_api_error(exc: google_exceptions.GoogleAPIError) -> str:
+    if isinstance(exc, google_exceptions.PermissionDenied):
+        return (
+            "The AI API key is invalid or has been revoked. "
+            "Generate a new key at https://aistudio.google.com/apikey "
+            "and update GEMINI_API_KEY in backend/.env."
+        )
+    if isinstance(exc, google_exceptions.ResourceExhausted):
+        return "AI service quota exceeded. Please try again later."
+    if isinstance(exc, google_exceptions.NotFound):
+        return (
+            f"The configured AI model ({settings.GEMINI_MODEL}) is not available. "
+            "Set GEMINI_MODEL in backend/.env to a supported model."
+        )
+    return "AI service is temporarily unavailable. Please try again."
 
 
 def _strip_json_fences(text: str) -> str:
@@ -148,6 +174,30 @@ def _ensure_ids(resume_data: dict) -> dict:
     return resume_data
 
 
+def _normalize_resume_data(resume_data: dict) -> dict:
+    if not isinstance(resume_data, dict):
+        return {}
+
+    resume_data.setdefault("fullName", "")
+    resume_data.setdefault("profileSummary", "")
+    resume_data.setdefault("experience", [])
+    resume_data.setdefault("education", [])
+    resume_data.setdefault("skills", [])
+    resume_data.setdefault("languages", [])
+    resume_data.setdefault("certifications", [])
+    resume_data.setdefault("extracurricular", [])
+
+    contact = resume_data.get("contact")
+    if not isinstance(contact, dict):
+        contact = {}
+    contact.setdefault("phone", "")
+    contact.setdefault("email", "")
+    contact.setdefault("location", "")
+    resume_data["contact"] = contact
+
+    return resume_data
+
+
 def update_resume_with_ai(resume_text: str, instructions: str) -> dict:
     """Parse resume text, apply user instructions via Gemini, return structured result."""
     if not resume_text or not resume_text.strip():
@@ -163,11 +213,14 @@ def update_resume_with_ai(resume_text: str, instructions: str) -> dict:
     )
 
     try:
-        model = genai.GenerativeModel(MODEL_NAME, system_instruction=SYSTEM_PROMPT)
+        model = genai.GenerativeModel(
+            settings.GEMINI_MODEL,
+            system_instruction=SYSTEM_PROMPT,
+        )
         response = model.generate_content(user_prompt)
         response_text = response.text
     except google_exceptions.GoogleAPIError as exc:
-        raise GeminiAPIError("AI service is temporarily unavailable. Please try again.") from exc
+        raise GeminiAPIError(_map_google_api_error(exc)) from exc
     except Exception as exc:
         raise GeminiAPIError("AI service is temporarily unavailable. Please try again.") from exc
 
@@ -175,6 +228,7 @@ def update_resume_with_ai(resume_text: str, instructions: str) -> dict:
         raise GeminiParseError("AI returned an empty response.")
 
     resume_data, changes = _parse_gemini_response(response_text)
+    resume_data = _normalize_resume_data(resume_data)
     resume_data = _ensure_ids(resume_data)
 
     return {"updated_resume": resume_data, "changes_made": changes}

--- a/backend/ai_updater/views.py
+++ b/backend/ai_updater/views.py
@@ -5,7 +5,13 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from ai_updater.utils.ai_client import update_resume_with_ai
+from ai_updater.utils.ai_client import (
+    GeminiAPIError,
+    GeminiConfigError,
+    GeminiParseError,
+    InvalidInputError,
+    update_resume_with_ai,
+)
 from ai_updater.utils.pdf_parser import extract_resume_text
 
 
@@ -16,6 +22,7 @@ class AIResumeUpdateView(APIView):
 
     def post(self, request):
         file = request.FILES.get("file")
+        supporting_file = request.FILES.get("supporting_file")
         instructions = request.data.get("instructions", "").strip()
 
         if not file:
@@ -43,6 +50,20 @@ class AIResumeUpdateView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        if supporting_file:
+            if supporting_file.size > self.MAX_FILE_SIZE:
+                return Response(
+                    {"error": "File too large. Maximum size is 5MB."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            supporting_extension = os.path.splitext(supporting_file.name)[1].lower()
+            if supporting_extension not in self.ALLOWED_EXTENSIONS:
+                return Response(
+                    {"error": "Only PDF and DOCX files are supported."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
         try:
             resume_text = extract_resume_text(file.read(), file.name)
         except ValueError as exc:
@@ -50,6 +71,19 @@ class AIResumeUpdateView(APIView):
                 {"error": str(exc)},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        supporting_text = ""
+        if supporting_file:
+            try:
+                supporting_text = extract_resume_text(
+                    supporting_file.read(),
+                    supporting_file.name,
+                )
+            except ValueError as exc:
+                return Response(
+                    {"error": str(exc)},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         if not resume_text or not resume_text.strip():
             return Response(
@@ -63,7 +97,24 @@ class AIResumeUpdateView(APIView):
             )
 
         try:
-            result = update_resume_with_ai(resume_text, instructions)
+            combined_text = resume_text
+            if supporting_text and supporting_text.strip():
+                combined_text = (
+                    "PRIMARY RESUME:\n"
+                    f"{resume_text.strip()}\n\n"
+                    "SUPPORTING DOCUMENT:\n"
+                    f"{supporting_text.strip()}\n"
+                )
+
+            result = update_resume_with_ai(combined_text, instructions)
+        except InvalidInputError as exc:
+            return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except GeminiConfigError as exc:
+            return Response({"error": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        except GeminiParseError as exc:
+            return Response({"error": str(exc)}, status=status.HTTP_502_BAD_GATEWAY)
+        except GeminiAPIError as exc:
+            return Response({"error": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
         except Exception:
             return Response(
                 {"error": "AI processing failed. Please try again."},

--- a/backend/resumify_backend/settings.py
+++ b/backend/resumify_backend/settings.py
@@ -171,6 +171,7 @@ SIMPLE_JWT = {
 }
 
 GEMINI_API_KEY = os.getenv('GEMINI_API_KEY', '')
+GEMINI_MODEL = os.getenv('GEMINI_MODEL', 'gemini-flash-latest')
 
 # File upload limit: 5MB
 DATA_UPLOAD_MAX_MEMORY_SIZE = 5 * 1024 * 1024

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>Resumify</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.17",
         "axios": "^1.13.2",
+        "jspdf": "^4.2.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.10.1",
@@ -262,6 +263,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1600,6 +1610,19 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmmirror.com/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.7.tgz",
@@ -1619,6 +1642,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.49.0",
@@ -1997,6 +2027,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.6",
       "resolved": "https://registry.npmmirror.com/baseline-browser-mapping/-/baseline-browser-mapping-2.9.6.tgz",
@@ -2096,6 +2136,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmmirror.com/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
@@ -2172,6 +2232,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmmirror.com/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2185,6 +2257,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -2235,6 +2317,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -2585,6 +2677,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmmirror.com/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
@@ -2601,6 +2704,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmmirror.com/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2869,6 +2978,20 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmmirror.com/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmmirror.com/ignore/-/ignore-5.3.2.tgz",
@@ -2905,6 +3028,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmmirror.com/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3010,6 +3139,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmmirror.com/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -3459,6 +3605,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/parent-module/-/parent-module-1.0.1.tgz",
@@ -3491,6 +3643,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3564,6 +3723,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmmirror.com/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.1",
       "resolved": "https://registry.npmmirror.com/react/-/react-19.2.1.tgz",
@@ -3633,6 +3802,13 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3641,6 +3817,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -3738,6 +3924,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmmirror.com/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3764,6 +3960,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.17",
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-4.1.17.tgz",
@@ -3781,6 +3987,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinyglobby": {
@@ -3909,6 +4125,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.17",
     "axios": "^1.13.2",
+    "jspdf": "^4.2.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.10.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Login from './pages/Login';
 import Register from './pages/Register';
 import ResumeBuilder from './pages/ResumeBuilder';
 import Preview from './pages/Preview';
+import AIResumeUpdater from './pages/AIResumeUpdater';
 
 function App() {
   const initialize = useAuthStore((state) => state.initialize);
@@ -47,6 +48,14 @@ function App() {
               element={
                 <ProtectedRoute>
                   <Preview />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/ai-updater"
+              element={
+                <ProtectedRoute>
+                  <AIResumeUpdater />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -13,12 +13,20 @@ const Navbar = () => {
               Resumify
             </Link>
             {isAuthenticated && (
-              <Link
-                to="/builder"
-                className="text-gray-700 hover:text-gray-900 text-sm font-medium"
-              >
-                Builder
-              </Link>
+              <>
+                <Link
+                  to="/builder"
+                  className="text-gray-700 hover:text-gray-900 text-sm font-medium"
+                >
+                  Builder
+                </Link>
+                <Link
+                  to="/ai-updater"
+                  className="text-gray-700 hover:text-gray-900 text-sm font-medium"
+                >
+                  AI Updater
+                </Link>
+              </>
             )}
           </div>
           <div className="flex items-center space-x-4">

--- a/frontend/src/components/ResumePreview.tsx
+++ b/frontend/src/components/ResumePreview.tsx
@@ -1,43 +1,234 @@
 import React from 'react';
-import type { Resume } from '../types';
+import type {
+  Certification,
+  Contact,
+  Education,
+  Experience,
+  Language,
+  Resume,
+} from '../types';
 
 interface ResumePreviewProps {
   resume: Resume;
+  previewId?: string;
 }
 
-const ResumePreview: React.FC<ResumePreviewProps> = ({ resume }) => {
+function formatDateRange(start: string, end: string): string {
+  const startTrimmed = start?.trim();
+  const endTrimmed = end?.trim();
+  if (startTrimmed && endTrimmed) return `${startTrimmed} – ${endTrimmed}`;
+  return startTrimmed || endTrimmed || '';
+}
+
+function renderDescription(description: string) {
+  const lines = description
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) return null;
+
+  if (lines.length === 1) {
+    return <p className="text-gray-700 text-sm mt-1 leading-relaxed">{lines[0]}</p>;
+  }
+
   return (
-    <div className="bg-white p-8 rounded-lg shadow-md max-w-4xl mx-auto">
-      <div className="mb-6">
-        <h1 className="text-3xl font-bold mb-2">{resume.fullName || 'Your Name'}</h1>
-        {resume.profileSummary && (
-          <p className="text-gray-700">{resume.profileSummary}</p>
+    <ul className="mt-2 space-y-1 list-disc list-outside ml-4 text-sm text-gray-700 leading-relaxed">
+      {lines.map((line, index) => {
+        const bullet = line.replace(/^[-•*]\s*/, '');
+        return <li key={index}>{bullet}</li>;
+      })}
+    </ul>
+  );
+}
+
+function ExperienceItem({ item }: { item: Experience }) {
+  const dates = formatDateRange(item.startDate, item.endDate);
+
+  return (
+    <div className="mb-4 last:mb-0">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-baseline gap-1">
+        <h3 className="font-semibold text-gray-900">
+          {item.position}
+          {item.company && (
+            <span className="font-normal text-gray-700"> · {item.company}</span>
+          )}
+        </h3>
+        {dates && <span className="text-sm text-gray-500 shrink-0">{dates}</span>}
+      </div>
+      {item.description && renderDescription(item.description)}
+    </div>
+  );
+}
+
+function EducationItem({ item }: { item: Education }) {
+  const dates = formatDateRange(item.startDate, item.endDate);
+  const degreeLine = [item.degree, item.field].filter(Boolean).join(' in ');
+
+  return (
+    <div className="mb-4 last:mb-0">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-baseline gap-1">
+        <div>
+          {degreeLine && <h3 className="font-semibold text-gray-900">{degreeLine}</h3>}
+          {item.institution && (
+            <p className="text-gray-700 text-sm">{item.institution}</p>
+          )}
+          {item.grade && <p className="text-gray-700 text-sm">GPA: {item.grade}</p>}
+        </div>
+        {dates && <span className="text-sm text-gray-500 shrink-0">{dates}</span>}
+      </div>
+    </div>
+  );
+}
+
+function CertificationItem({ item }: { item: Certification }) {
+  return (
+    <div className="mb-3 last:mb-0 flex flex-col sm:flex-row sm:justify-between sm:items-baseline gap-1">
+      <div>
+        <span className="font-medium text-gray-900">{item.name}</span>
+        {item.issuer && (
+          <span className="text-gray-700 text-sm"> · {item.issuer}</span>
         )}
       </div>
+      {item.date && <span className="text-sm text-gray-500 shrink-0">{item.date}</span>}
+    </div>
+  );
+}
 
-      {resume.experience && resume.experience.length > 0 && (
-        <div className="mb-6">
-          <h2 className="text-2xl font-semibold mb-4 border-b pb-2">Experience</h2>
-          <p className="text-gray-500 text-sm">Experience items - to be implemented</p>
-        </div>
+function LanguageItem({ item }: { item: Language }) {
+  return (
+    <span className="inline-flex items-center gap-1 mr-4 mb-2 text-sm text-gray-700">
+      <span className="font-medium text-gray-900">{item.name}</span>
+      {item.proficiency && (
+        <span className="text-gray-500">({item.proficiency})</span>
+      )}
+    </span>
+  );
+}
+
+function ContactBlock({ contact }: { contact: Contact }) {
+  const phone = contact.phone?.trim();
+  const email = contact.email?.trim();
+  const location = contact.location?.trim();
+
+  if (!phone && !email && !location) return null;
+
+  return (
+    <div className="text-sm text-gray-700">
+      <div className="flex flex-wrap justify-center gap-x-2 gap-y-1">
+        {location && <span className="whitespace-pre-line">{location}</span>}
+        {location && (phone || email) && <span className="text-gray-400">|</span>}
+        {phone && <span>{phone}</span>}
+        {phone && email && <span className="text-gray-400">|</span>}
+        {email && <span>{email}</span>}
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-6 last:mb-0">
+      <h2 className="text-sm font-extrabold uppercase tracking-widest text-gray-900">
+        {title === 'WorkExperience' ? 'Experience' : title}
+      </h2>
+      <hr className="resume-section-line my-2 border-0 border-t-2 border-gray-900" />
+      {children}
+    </section>
+  );
+}
+
+const ResumePreview: React.FC<ResumePreviewProps> = ({ resume, previewId }) => {
+  const contact = resume.contact;
+  const experience = resume.experience ?? [];
+  const education = resume.education ?? [];
+  const skills = resume.skills ?? [];
+  const languages = resume.languages ?? [];
+  const certifications = resume.certifications ?? [];
+  const extracurricular = resume.extracurricular ?? [];
+
+  return (
+    <div
+      id={previewId}
+      className="bg-white p-8 sm:p-10 rounded-lg shadow-md max-w-4xl mx-auto print:shadow-none print:p-0"
+    >
+      <header className="text-center mb-6">
+        <h1 className="text-4xl sm:text-5xl font-extrabold tracking-wide text-gray-900">
+          {resume.fullName || 'Your Name'}
+        </h1>
+        {contact && (
+          <div className="mt-2">
+            <ContactBlock contact={contact} />
+          </div>
+        )}
+        <hr className="resume-section-line mt-4 border-0 border-t-2 border-gray-900" />
+      </header>
+
+      {resume.profileSummary && (
+        <Section title="Professional Summary">
+          <p className="text-gray-800 leading-relaxed text-sm sm:text-base">
+            {resume.profileSummary}
+          </p>
+        </Section>
       )}
 
-      {resume.education && resume.education.length > 0 && (
-        <div className="mb-6">
-          <h2 className="text-2xl font-semibold mb-4 border-b pb-2">Education</h2>
-          <p className="text-gray-500 text-sm">Education items - to be implemented</p>
-        </div>
+      {education.length > 0 && (
+        <Section title="Education">
+          {education.map((item, index) => (
+            <EducationItem key={item.id ?? index} item={item} />
+          ))}
+        </Section>
       )}
 
-      {resume.skills && resume.skills.length > 0 && (
-        <div className="mb-6">
-          <h2 className="text-2xl font-semibold mb-4 border-b pb-2">Skills</h2>
-          <p className="text-gray-500 text-sm">Skills list - to be implemented</p>
-        </div>
+      {experience.length > 0 && (
+        <Section title="WorkExperience">
+          {experience.map((item, index) => (
+            <ExperienceItem key={item.id ?? index} item={item} />
+          ))}
+        </Section>
+      )}
+
+      {skills.length > 0 && (
+        <Section title="Skills">
+          <div className="flex flex-wrap gap-x-3 gap-y-1 text-sm text-gray-800">
+            {skills.map((skill, index) => (
+              <span key={index} className="whitespace-nowrap">
+                {skill}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {certifications.length > 0 && (
+        <Section title="Certifications">
+          {certifications.map((item, index) => (
+            <CertificationItem key={item.id ?? index} item={item} />
+          ))}
+        </Section>
+      )}
+
+      {languages.length > 0 && (
+        <Section title="Languages">
+          <div className="flex flex-wrap">
+            {languages.map((item, index) => (
+              <LanguageItem key={item.id ?? index} item={item} />
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {extracurricular.length > 0 && (
+        <Section title="Extracurricular">
+          <ul className="list-disc list-outside ml-4 space-y-1 text-sm text-gray-800">
+            {extracurricular.map((item, index) => (
+              <li key={index}>{item}</li>
+            ))}
+          </ul>
+        </Section>
       )}
     </div>
   );
 };
 
 export default ResumePreview;
-

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,3 +5,56 @@
     @apply bg-gray-50 text-gray-900;
   }
 }
+
+@media print {
+  @page {
+    size: letter portrait;
+    margin: 0;
+  }
+
+  nav,
+  button,
+  .no-print {
+    display: none !important;
+  }
+
+  html,
+  body {
+    background: white !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  /* Hide everything on the page … */
+  body * {
+    visibility: hidden;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+
+  /* … then reveal only the resume element and its children */
+  #resume-preview-print,
+  #resume-preview-print * {
+    visibility: visible;
+  }
+
+  #resume-preview-print {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 0.5in !important;
+    box-sizing: border-box !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    max-width: none !important;
+    margin: 0 !important;
+    background: white !important;
+  }
+
+  .resume-section-line {
+    border-top: 2px solid #111827 !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+}

--- a/frontend/src/pages/AIResumeUpdater.tsx
+++ b/frontend/src/pages/AIResumeUpdater.tsx
@@ -1,0 +1,355 @@
+import { useRef, useState } from 'react';
+import ResumePreview from '../components/ResumePreview';
+import { useAIUpdaterStore } from '../store/aiUpdaterStore';
+import { createResume, getApiErrorMessage, updateResumeWithAI } from '../utils/api';
+import { downloadResumePdf } from '../utils/printResume';
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+const ALLOWED_EXTENSIONS = ['.pdf', '.docx'];
+const ALLOWED_MIMES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+];
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function validateFile(file: File): string | null {
+  const extension = file.name.slice(file.name.lastIndexOf('.')).toLowerCase();
+  const hasValidExtension = ALLOWED_EXTENSIONS.includes(extension);
+  const hasValidMime = !file.type || ALLOWED_MIMES.includes(file.type);
+
+  if (!hasValidExtension && !hasValidMime) {
+    return 'Only PDF and DOCX files are supported.';
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return 'File too large. Maximum size is 5MB.';
+  }
+
+  return null;
+}
+
+const AIResumeUpdater = () => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const supportingFileInputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const {
+    status,
+    uploadedFile,
+    supportingFile,
+    instructions,
+    updatedResume,
+    changesMade,
+    error,
+    setFile,
+    setSupportingFile,
+    setInstructions,
+    setProcessing,
+    setResult,
+    setError,
+    reset,
+  } = useAIUpdaterStore();
+
+  const isProcessing = status === 'processing';
+
+  const handleFileSelect = (file: File) => {
+    const validationError = validateFile(file);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setFile(file);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFileSelect(file);
+    e.target.value = '';
+  };
+
+  const handleSupportingFileSelect = (file: File) => {
+    const validationError = validateFile(file);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setSupportingFile(file);
+  };
+
+  const handleSupportingInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleSupportingFileSelect(file);
+    e.target.value = '';
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (!isProcessing) setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    if (isProcessing) return;
+
+    const file = e.dataTransfer.files[0];
+    if (file) handleFileSelect(file);
+  };
+
+  const handleSubmit = async () => {
+    if (!uploadedFile) {
+      setError('Please upload your resume file.');
+      return;
+    }
+
+    if (!instructions.trim()) {
+      setError('Please describe what changes you want.');
+      return;
+    }
+
+    setProcessing();
+
+    try {
+      const data = await updateResumeWithAI(uploadedFile, instructions.trim(), supportingFile);
+      setResult(data.updated_resume, data.changes_made);
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Something went wrong. Please try again.'));
+    }
+  };
+
+  const handleSave = async () => {
+    if (!updatedResume) return;
+
+    setSaving(true);
+    try {
+      await createResume(`${updatedResume.fullName} — Updated`, updatedResume);
+      alert('Resume saved successfully!');
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Failed to save resume.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDownloadPdf = () => {
+    if (!updatedResume) return;
+    setError('');
+    try {
+      downloadResumePdf();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to open print dialog.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h1 className="text-3xl font-bold mb-6 no-print">AI Resume Updater</h1>
+
+        {error && (
+          <div className="mb-4 p-4 bg-red-50 border border-red-200 text-red-700 rounded-lg no-print">
+            {error}
+          </div>
+        )}
+
+        {status !== 'done' && (
+          <>
+            <div className="bg-white rounded-lg shadow-md p-6 mb-6 no-print">
+              <h2 className="text-xl font-semibold mb-4">Step 1 — Upload Your Resume</h2>
+              <div
+                role="button"
+                tabIndex={0}
+                onClick={() => !isProcessing && fileInputRef.current?.click()}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    if (!isProcessing) fileInputRef.current?.click();
+                  }
+                }}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+                  isDragging
+                    ? 'border-blue-500 bg-blue-50'
+                    : 'border-gray-300 hover:border-blue-400 hover:bg-gray-50'
+                } ${isProcessing ? 'opacity-50 pointer-events-none' : ''}`}
+              >
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".pdf,.docx"
+                  onChange={handleInputChange}
+                  className="hidden"
+                  disabled={isProcessing}
+                />
+                {uploadedFile ? (
+                  <div>
+                    <p className="text-gray-900 font-medium">{uploadedFile.name}</p>
+                    <p className="text-gray-500 text-sm mt-1">
+                      {formatFileSize(uploadedFile.size)}
+                    </p>
+                    <p className="text-blue-600 text-sm mt-2">Click or drag to replace</p>
+                  </div>
+                ) : (
+                  <div>
+                    <p className="text-gray-700">
+                      Drag and drop your resume here, or click to browse
+                    </p>
+                    <p className="text-gray-500 text-sm mt-2">PDF or DOCX, max 5MB</p>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-md p-6 mb-6 no-print">
+              <h2 className="text-xl font-semibold mb-4">
+                Step 2 — Optional Supporting Document
+              </h2>
+              <p className="text-sm text-gray-500 mb-4">
+                Upload an internship certificate or reference to help the AI add missing experience.
+              </p>
+
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                <div>
+                  {supportingFile ? (
+                    <>
+                      <p className="text-gray-900 font-medium">{supportingFile.name}</p>
+                      <p className="text-gray-500 text-sm mt-1">
+                        {formatFileSize(supportingFile.size)}
+                      </p>
+                    </>
+                  ) : (
+                    <p className="text-gray-600 text-sm">No supporting file selected.</p>
+                  )}
+                </div>
+                <div className="flex gap-2">
+                  <input
+                    ref={supportingFileInputRef}
+                    type="file"
+                    accept=".pdf,.docx"
+                    onChange={handleSupportingInputChange}
+                    className="hidden"
+                    disabled={isProcessing}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => !isProcessing && supportingFileInputRef.current?.click()}
+                    className="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium hover:bg-gray-100 disabled:opacity-50"
+                    disabled={isProcessing}
+                  >
+                    {supportingFile ? 'Replace file' : 'Choose file'}
+                  </button>
+                  {supportingFile && (
+                    <button
+                      type="button"
+                      onClick={() => setSupportingFile(null)}
+                      className="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium hover:bg-gray-100 disabled:opacity-50"
+                      disabled={isProcessing}
+                    >
+                      Remove
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow-md p-6 mb-6 no-print">
+              <h2 className="text-xl font-semibold mb-4">Step 3 — Describe Your Changes</h2>
+              <textarea
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                disabled={isProcessing}
+                rows={5}
+                placeholder="Add HSE Intern experience at D.G. Khan Cement Company Limited (Nishat Group), Khairpur Plant, based on the supporting document. Keep all existing jobs and overall layout unchanged. Place the new internship at the top of Work Experience."
+                className="w-full border border-gray-300 rounded-lg p-3 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
+              />
+            </div>
+
+            <div className="no-print">
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={isProcessing}
+                className="bg-blue-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Update My Resume
+              </button>
+            </div>
+
+            {isProcessing && (
+              <div className="mt-6 flex items-center gap-3 no-print">
+                <div className="h-6 w-6 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
+                <p className="text-gray-600">AI is updating your resume...</p>
+              </div>
+            )}
+          </>
+        )}
+
+        {status === 'done' && updatedResume && (
+          <>
+            <div className="bg-white rounded-lg shadow-md p-6 mb-6 no-print">
+              <h2 className="text-xl font-semibold mb-4">Changes Applied</h2>
+              {changesMade.length > 0 ? (
+                <ul className="list-disc list-inside space-y-1 text-gray-700">
+                  {changesMade.map((change, index) => (
+                    <li key={index}>{change}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-gray-500">No specific changes were listed.</p>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-3 mb-6 no-print">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving}
+                className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors disabled:opacity-50"
+              >
+                {saving ? 'Saving...' : 'Save to My Resumes'}
+              </button>
+              <button
+                type="button"
+                onClick={handleDownloadPdf}
+                className="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium hover:bg-gray-100"
+              >
+                Download PDF
+              </button>
+              <button
+                type="button"
+                onClick={reset}
+                className="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium hover:bg-gray-100"
+              >
+                Start over
+              </button>
+            </div>
+
+            <div className="mb-2 no-print">
+              <h2 className="text-xl font-semibold">Updated Resume Preview</h2>
+              <p className="text-sm text-gray-500 mt-1">
+                Review the full resume below before saving or printing.
+              </p>
+            </div>
+
+            <ResumePreview resume={updatedResume} previewId="resume-preview-print" />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AIResumeUpdater;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -13,12 +13,18 @@ const Home = () => {
             Build beautiful, ATS-friendly resumes with our easy-to-use resume builder.
             No design skills required.
           </p>
-          <div className="flex justify-center space-x-4">
+          <div className="flex justify-center flex-wrap gap-4">
             <Link
               to="/builder"
               className="bg-blue-600 text-white px-8 py-3 rounded-lg text-lg font-semibold hover:bg-blue-700 transition-colors"
             >
               Start Building
+            </Link>
+            <Link
+              to="/ai-updater"
+              className="bg-white text-blue-600 px-8 py-3 rounded-lg text-lg font-semibold border-2 border-blue-600 hover:bg-blue-50 transition-colors"
+            >
+              Update with AI
             </Link>
             <Link
               to="/login"

--- a/frontend/src/pages/ResumeBuilder.tsx
+++ b/frontend/src/pages/ResumeBuilder.tsx
@@ -9,11 +9,13 @@ import { createResume, getApiErrorMessage, getResume, updateResume } from '../ut
 const emptyResume = (): Resume => ({
   fullName: '',
   profileSummary: '',
+  contact: { phone: '', email: '', location: '' },
   experience: [],
   education: [],
   skills: [],
   languages: [],
   certifications: [],
+  extracurricular: [],
 });
 
 const ResumeBuilder = () => {

--- a/frontend/src/store/aiUpdaterStore.ts
+++ b/frontend/src/store/aiUpdaterStore.ts
@@ -6,12 +6,14 @@ type Status = 'idle' | 'processing' | 'done' | 'error';
 interface AIUpdaterState {
   status: Status;
   uploadedFile: File | null;
+  supportingFile: File | null;
   instructions: string;
   updatedResume: Resume | null;
   changesMade: string[];
   error: string | null;
 
   setFile: (file: File | null) => void;
+  setSupportingFile: (file: File | null) => void;
   setInstructions: (text: string) => void;
   setProcessing: () => void;
   setResult: (resume: Resume, changes: string[]) => void;
@@ -22,13 +24,15 @@ interface AIUpdaterState {
 export const useAIUpdaterStore = create<AIUpdaterState>((set) => ({
   status: 'idle',
   uploadedFile: null,
+  supportingFile: null,
   instructions: '',
   updatedResume: null,
   changesMade: [],
   error: null,
 
   setFile: (file) => set({ uploadedFile: file, status: 'idle', error: null }),
-  setInstructions: (text) => set({ instructions: text }),
+  setSupportingFile: (file) => set({ supportingFile: file, status: 'idle', error: null }),
+  setInstructions: (text) => set({ instructions: text, error: null }),
   setProcessing: () => set({ status: 'processing', error: null }),
   setResult: (resume, changes) =>
     set({ status: 'done', updatedResume: resume, changesMade: changes }),
@@ -37,6 +41,7 @@ export const useAIUpdaterStore = create<AIUpdaterState>((set) => ({
     set({
       status: 'idle',
       uploadedFile: null,
+      supportingFile: null,
       instructions: '',
       updatedResume: null,
       changesMade: [],

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2,11 +2,19 @@ export type Resume = {
   id?: number;
   fullName: string;
   profileSummary: string;
+  contact: Contact;
   experience: Experience[];
   education: Education[];
   skills: string[];
   languages: Language[];
   certifications: Certification[];
+  extracurricular: string[];
+};
+
+export type Contact = {
+  phone: string;
+  email: string;
+  location: string;
 };
 
 export type Experience = {
@@ -25,6 +33,7 @@ export type Education = {
   field: string;
   startDate: string;
   endDate: string;
+  grade?: string;
 };
 
 export type Language = {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -89,11 +89,15 @@ export async function updateResume(
 
 export async function updateResumeWithAI(
   file: File,
-  instructions: string
+  instructions: string,
+  supportingFile?: File | null
 ): Promise<AIUpdateResult> {
   const formData = new FormData();
   formData.append('file', file);
   formData.append('instructions', instructions);
+  if (supportingFile) {
+    formData.append('supporting_file', supportingFile);
+  }
 
   const response = await api.post<AIUpdateResult>('/ai-updater/update/', formData, {
     headers: { 'Content-Type': 'multipart/form-data' },

--- a/frontend/src/utils/printResume.ts
+++ b/frontend/src/utils/printResume.ts
@@ -1,0 +1,7 @@
+export function downloadResumePdf(): void {
+  const element = document.getElementById('resume-preview-print');
+  if (!element) {
+    throw new Error('Resume preview not found. Please update your resume first.');
+  }
+  window.print();
+}


### PR DESCRIPTION
…t (#21)

Implement Phase 7 frontend for authenticated users to upload a resume, optionally attach a supporting document (e.g. internship certificate), describe changes in natural language, preview the AI-updated result, save it to their account, or download a clean PDF without browser headers.

Frontend:
- Add AIResumeUpdater page with drag-and-drop upload, optional supporting file, instructions textarea, changes list, and result actions
- Register protected /ai-updater route and navbar/Home CTAs
- Extend Resume schema with contact, extracurricular, and education grades
- Rebuild ResumePreview as a single-column layout matching resume PDFs (centered name, section dividers, full experience/education/skills)
- Add supporting_file to aiUpdaterStore and updateResumeWithAI API helper
- Add PDF download via modern-screenshot + jsPDF (Tailwind v4/oklch safe, no browser print headers); rename app title to Resumify
- Add print CSS for resume-only output

Backend:
- Accept optional supporting_file on POST /api/ai-updater/update/
- Improve Gemini prompt for multi-column PDF text and certificate merges
- Add resume JSON normalization (contact defaults, array fallbacks)
- Map Gemini API errors to user-friendly 503 messages; add GEMINI_MODEL setting (default gemini-flash-latest)
- Add tests for supporting file upload and API error responses

Closes #21 