### PR TITLE
feat: complete AI Resume Updater routing and polish (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Resumify
 
-A full-stack Resume Generator platform with modern UI, backend APIs, and future AI features.
+A full-stack Resume Generator platform with modern UI, backend APIs, and AI-powered resume updates.
 
 ## Tech Stack
 
@@ -27,6 +27,7 @@ resumify/
 │   ├── resumify_backend/  # Django project settings
 │   ├── users/            # User management app
 │   ├── resumes/          # Resume CRUD app
+│   ├── ai_updater/       # AI resume update (Gemini)
 │   └── requirements.txt
 └── README.md
 ```
@@ -85,6 +86,10 @@ python manage.py migrate
 python manage.py createsuperuser
 ```
 
+7. Configure environment variables (copy `backend/.env.example` to `backend/.env`):
+   - `GEMINI_API_KEY` — required for the AI Resume Updater (`/ai-updater`)
+   - `GEMINI_MODEL` — optional, defaults to `gemini-flash-latest`
+
 ## Running the Application
 
 ### Frontend
@@ -119,6 +124,9 @@ The backend API will be available at `http://localhost:8000`
 - `DELETE /api/resumes/:id/` - Delete a resume
 - `GET /api/my-resumes/` - Get all resumes for current user
 
+### AI Resume Updater
+- `POST /api/ai-updater/update/` - Update a resume with AI (authenticated, multipart: `file`, `instructions`, optional `supporting_file`; PDF/DOCX, max 5MB each)
+
 ## Frontend Pages
 
 - `/` - Home page
@@ -126,6 +134,7 @@ The backend API will be available at `http://localhost:8000`
 - `/register` - Registration page
 - `/builder` - Resume builder page
 - `/preview/:id` - Resume preview page
+- `/ai-updater` - AI Resume Updater (authenticated)
 
 ## Development Notes
 
@@ -136,11 +145,8 @@ The backend API will be available at `http://localhost:8000`
 
 ## Next Steps
 
-- Implement full resume form functionality
-- Add PDF generation
-- Implement user authentication on frontend
-- Add AI features for resume enhancement
 - Add resume templates
+- Add DOCX export for AI-updated resumes
 
 ## License
 

--- a/frontend/src/pages/AIResumeUpdater.tsx
+++ b/frontend/src/pages/AIResumeUpdater.tsx
@@ -144,7 +144,6 @@ const AIResumeUpdater = () => {
 
   const handleDownloadPdf = () => {
     if (!updatedResume) return;
-    setError('');
     try {
       downloadResumePdf();
     } catch (err) {

--- a/frontend/src/store/aiUpdaterStore.ts
+++ b/frontend/src/store/aiUpdaterStore.ts
@@ -36,7 +36,11 @@ export const useAIUpdaterStore = create<AIUpdaterState>((set) => ({
   setProcessing: () => set({ status: 'processing', error: null }),
   setResult: (resume, changes) =>
     set({ status: 'done', updatedResume: resume, changesMade: changes }),
-  setError: (message) => set({ status: 'error', error: message }),
+  setError: (message) =>
+    set((state) => ({
+      error: message || null,
+      ...(state.status !== 'done' && message ? { status: 'error' as const } : {}),
+    })),
   reset: () =>
     set({
       status: 'idle',


### PR DESCRIPTION
## Summary
- Fixes `setError` in the AI updater store so save/print failures no longer hide the results preview when `status === 'done'`
- Removes unnecessary `setError('')` call before print
- Documents `/ai-updater`, `POST /api/ai-updater/update/`, and `GEMINI_*` env vars in README

Closes #23

## Test plan
- [x] `python3 manage.py test ai_updater` — 41 tests pass
- [x] `npm run build` — succeeds
- [ ] Log in, click **AI Updater** in navbar → lands on `/ai-updater`
- [ ] Submit without file or instructions → inline validation errors
- [ ] Upload `.txt` file → "Only PDF and DOCX…" error
- [ ] Upload valid PDF + instructions → spinner → preview + changes list
- [ ] Repeat with supporting PDF → new experience appears per instructions
- [ ] Click **Save to My Resumes** → success; resume visible in builder
- [ ] Click **Download PDF** → print dialog shows resume only (no nav/buttons)
- [ ] Click **Start over** → form resets to Step 1
- [ ] Log out, visit `/ai-updater` directly → redirect to login
- [ ] Backend with missing `GEMINI_API_KEY` → 503 with helpful error


Made with [Cursor](https://cursor.com)